### PR TITLE
fix: update Gemini transformer googleSearch parameter name

### DIFF
--- a/src/transformer/gemini.transformer.ts
+++ b/src/transformer/gemini.transformer.ts
@@ -59,7 +59,7 @@ export class GeminiTransformer implements Transformer {
     const webSearch = request.tools?.find((tool) => tool.function.name === "web_search")
     if (webSearch) {
       tools.push({
-        google_search: {},
+        googleSearch: {},
       })
     }
     return {


### PR DESCRIPTION
更新gemini格式web search 转换后的函数，使其更符合规范与行业的普遍做法。现在的实现同时支持gemini 官网调用以及第三方api调用