### PR TITLE
feat: add cached content token count to usage metrics for gemini tran…

### DIFF
--- a/src/utils/gemini.util.ts
+++ b/src/utils/gemini.util.ts
@@ -238,6 +238,7 @@ export async function transformResponseOut(response: Response, providerName: str
       usage: {
         completion_tokens: jsonResponse.usageMetadata.candidatesTokenCount,
         prompt_tokens: jsonResponse.usageMetadata.promptTokenCount,
+        cached_content_token_count: jsonResponse.usageMetadata.cachedContentTokenCount || null,
         total_tokens: jsonResponse.usageMetadata.totalTokenCount,
       },
     };
@@ -305,6 +306,7 @@ export async function transformResponseOut(response: Response, providerName: str
               usage: {
                 completion_tokens: chunk.usageMetadata.candidatesTokenCount,
                 prompt_tokens: chunk.usageMetadata.promptTokenCount,
+                cached_content_token_count: chunk.usageMetadata.cachedContentTokenCount || null,
                 total_tokens: chunk.usageMetadata.totalTokenCount,
               },
             };


### PR DESCRIPTION
From Gemini 2.5, google has supported [Context Caching](https://ai.google.dev/gemini-api/docs/caching?lang=python) and returned cached token count.

<img width="5190" height="1684" alt="image" src="https://github.com/user-attachments/assets/34256b9c-aec3-4c02-96f6-779979774a52" />
