### PR TITLE
feat: Add Cerebras transformer

### DIFF
--- a/src/transformer/cerebras.transformer.ts
+++ b/src/transformer/cerebras.transformer.ts
@@ -1,0 +1,96 @@
+import { LLMProvider, UnifiedChatRequest, UnifiedMessage } from "@/types/llm";
+import { Transformer } from "@/types/transformer";
+
+/**
+ * Converts content from Claude Code format (array of objects) to plain string
+ * @param content - The content to convert
+ * @returns The converted string content
+ */
+function convertContentToString(content: any): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  
+  if (Array.isArray(content)) {
+    return content
+      .map(item => {
+        if (typeof item === 'string') {
+          return item;
+        }
+        if (item.type === 'text' && item.text) {
+          return item.text;
+        }
+        return '';
+      })
+      .join('');
+  }
+  
+  return '';
+}
+
+/**
+ * Transformer class for Cerebras
+ */
+export class CerebrasTransformer implements Transformer {
+  name = "cerebras";
+  endPoint = "/v1/chat/completions";
+
+  /**
+   * Transform the request from Claude Code format to Cerebras format
+   * @param request - The incoming request
+   * @param provider - The LLM provider information
+   * @returns The transformed request
+   */
+  async transformRequestIn(
+    request: UnifiedChatRequest,
+    provider: LLMProvider
+  ): Promise<Record<string, any>> {
+    // Deep clone the request to avoid modifying the original
+    const transformedRequest = JSON.parse(JSON.stringify(request));
+    
+    // Transform messages
+    if (transformedRequest.messages && Array.isArray(transformedRequest.messages)) {
+      transformedRequest.messages = transformedRequest.messages.map((message: UnifiedMessage) => {
+        const transformedMessage: any = { ...message };
+        
+        // Convert content to string format
+        if (message.content !== undefined) {
+          transformedMessage.content = convertContentToString(message.content);
+        }
+        
+        // Handle system messages specifically
+        if (message.role === 'system' && message.content !== undefined) {
+          transformedMessage.content = convertContentToString(message.content);
+        }
+        
+        return transformedMessage;
+      });
+    }
+    
+    // Handle system field if it exists at the top level
+    if (transformedRequest.system !== undefined) {
+      transformedRequest.system = convertContentToString(transformedRequest.system);
+    }
+    
+    return {
+      body: transformedRequest,
+      config: {
+        headers: {
+          'Authorization': `Bearer ${provider.apiKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    };
+  }
+
+  /**
+   * Transform the response
+   * @param response - The response from Cerebras
+   * @returns The transformed response
+   */
+  async transformResponseOut(response: Response): Promise<Response> {
+    // Cerebras responses should be compatible with Claude Code
+    // No transformation needed
+    return response;
+  }
+}

--- a/src/transformer/index.ts
+++ b/src/transformer/index.ts
@@ -13,10 +13,11 @@ import { ReasoningTransformer } from "./reasoning.transformer";
 import { SamplingTransformer } from "./sampling.transformer";
 import { MaxCompletionTokens } from "./maxcompletiontokens.transformer";
 import { VertexClaudeTransformer } from "./vertex-claude.transformer";
+import { CerebrasTransformer } from "./cerebras.transformer";
 
 export default {
   AnthropicTransformer,
-
+  
   GeminiTransformer,
   VertexGeminiTransformer,
   VertexClaudeTransformer,
@@ -29,5 +30,6 @@ export default {
   EnhanceToolTransformer,
   ReasoningTransformer,
   SamplingTransformer,
-  MaxCompletionTokens
+  MaxCompletionTokens,
+  CerebrasTransformer
 };


### PR DESCRIPTION
This transformer allows to use the Cerebras API (at api.cerebras.ai, not the one on OpenRouter) with claude-code-router. All credit goes to DigiBugCat, see https://github.com/musistudio/claude-code-router/issues/407#issuecomment-3146030329

Related to issue: https://github.com/musistudio/claude-code-router/issues/407

Works fully as tested on my free tier.

<img width="698" height="129" alt="Screenshot 2025-08-04 233707" src="https://github.com/user-attachments/assets/57f56738-7fb8-4926-b6c1-1dd027dd7cd8" />

Use this `.claude-code-router/config.json`.

```json
{
  "LOG": true,
  "OPENAI_API_KEY": "",
  "OPENAI_BASE_URL": "",
  "OPENAI_MODEL": "",
  "Providers": [
    {
      "name": "cerebras",
      "api_base_url": "https://api.cerebras.ai/v1/chat/completions",
      "api_key": "<your API key here>",
      "models": ["qwen-3-coder-480b"],
      "transformer": {
        "use": ["cerebras"]
      }
    }
  ],
  "Router": {
    "default": "cerebras,qwen-3-coder-480b"
  }
}
```

Unfortunately it does seem like the entire context is sent to Cerebras after every tool call, which leads to a lot more token usage compared to using native Claude Sonnet. This is the same behavior as other providers I've tried on claude-code-router (namely Groq), so I am assuming that this isn't a breaking issue.

If needed I can also add documentation in `claude-code-router`.