### PR TITLE
fix(gemini): fix gemini api error "only allowed for STRING type"

### DIFF
--- a/src/utils/gemini.util.ts
+++ b/src/utils/gemini.util.ts
@@ -16,6 +16,10 @@ export function cleanupParameters(obj: any) {
   delete obj.additionalProperties;
   delete obj.const;
 
+  if (obj.enum && obj.type !== "string") {
+    delete obj.enum;
+  }
+
   if (
     obj.type === "string" &&
     obj.format &&


### PR DESCRIPTION
调用gemini 2.5 pro时，有概率遇到gemini接口400报错 报错如下：
```
* GenerateContentRequest.tools[0].function_declarations[14].parameters.properties[truncateMode].enum: only allowed for STRING type * GenerateContentRequest.tools[0].function_declarations[27].parameters.properties[truncateMode].enum: only allowed for STRING type * GenerateContentRequest.tools[0].function_declarations[33].parameters.properties[truncateMode].enum: only allowed for STRING type

```
详见 https://github.com/musistudio/claude-code-router/issues/475