### PR TITLE
修复：使用 delete 移除 host 请求头以避免错误转换

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -178,9 +178,9 @@ async function sendRequestToProvider(
       if (auth.config?.headers) {
         headers = {
           ...headers,
-          host: undefined,
           ...auth.config.headers,
         };
+        delete headers.host;
         delete auth.config.headers;
       }
       config = {


### PR DESCRIPTION
## 变更描述

本次修改解决了在请求头处理中的一个潜在 Bug。

在之前的实现中，当需要移除请求头中的 `host` 字段时，代码会将其设置为 `undefined`。然而，这个 `undefined` 值在后续处理中会被强制类型转换为字符串 `"undefined"`，导致向服务端发送了错误的 `host` 请求头。

本次修改将逻辑更改为使用 `delete` 操作符，从而彻底地从请求头对象中移除 `host` 字段，确保不会传递任何无效值。

## 主要改动
- 将 `headers.host = undefined;` 的写法替换为 `delete headers.host;`

## 影响文件
- `src/api/routes.ts`