### PR TITLE
Add the OpenAITransformer to index.ts for creating /v1/chat/completio…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musistudio/llms",
-  "version": "1.0.15",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musistudio/llms",
-      "version": "1.0.15",
+      "version": "1.0.28",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.54.0",

--- a/src/transformer/index.ts
+++ b/src/transformer/index.ts
@@ -14,6 +14,7 @@ import { MaxCompletionTokens } from "./maxcompletiontokens.transformer";
 import { VertexClaudeTransformer } from "./vertex-claude.transformer";
 import { CerebrasTransformer } from "./cerebras.transformer";
 import { StreamOptionsTransformer } from "./streamoptions.transformer";
+import { OpenAITransformer } from "./openai.transformer";
 
 export default {
   AnthropicTransformer,
@@ -23,6 +24,7 @@ export default {
   DeepseekTransformer,
   TooluseTransformer,
   OpenrouterTransformer,
+  OpenAITransformer,
   MaxTokenTransformer,
   GroqTransformer,
   CleancacheTransformer,


### PR DESCRIPTION
OpenAITransformer didn't put into the index.ts, so it didn't create the endPoint /v1/chat/completion for the OpenAI compatible API use.