### PR TITLE
对 Antropic Transformer 增加一个可选的 boolean 变量，用于切换认证方式

### DIFF
--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -13,15 +13,27 @@ import { createApiError } from "@/api/middleware";
 export class AnthropicTransformer implements Transformer {
   name = "Anthropic";
   endPoint = "/v1/messages";
+  private useBearer: boolean;
+
+  constructor(private readonly options?: TransformerOptions) {
+    this.useBearer = this.options?.UseBearer ?? false;
+  }
 
   async auth(request: any, provider: LLMProvider): Promise<any> {
+    const headers: Record<string, string | undefined> = {};
+    
+    if (this.useBearer) {
+      headers["authorization"] = `Bearer ${provider.apiKey}`;
+      headers["x-api-key"] = undefined;
+    } else {
+      headers["x-api-key"] = provider.apiKey;
+      headers["authorization"] = undefined;
+    }
+
     return {
       body: request,
       config: {
-        headers: {
-          "x-api-key": provider.apiKey,
-          authorization: undefined,
-        },
+        headers,
       },
     };
   }

--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -5,7 +5,7 @@ import {
   UnifiedMessage,
   UnifiedTool,
 } from "@/types/llm";
-import { Transformer, TransformerContext } from "@/types/transformer";
+import { Transformer, TransformerContext, TransformerOptions } from "@/types/transformer";
 import { v4 as uuidv4 } from "uuid";
 import { getThinkLevel } from "@/utils/thinking";
 import { createApiError } from "@/api/middleware";


### PR DESCRIPTION
对于部分第三方站，其为限制用途，不接受使用 apikey 的请求的认证方式，只接受使用`AUTH_TOKEN`形式的请求
通过抓取分析两种模式的不同，为Antropic Transformer 设置一个可选的参数值，用于替换请求体中的鉴权字段。