### PR TITLE
feat: 为 AnthropicTransformer 添加可配置的 user-agent 支持

### DIFF
--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -30,6 +30,20 @@ export class AnthropicTransformer implements Transformer {
       headers["authorization"] = undefined;
     }
 
+    // 设置 user-agent 逻辑：
+    // 1. 如果 options 中有 userAgent，使用它
+    // 2. 如果没有，检查原始请求中是否已有 user-agent，如果有则保持不变
+    // 3. 如果都没有，使用默认值 "claude-cli/1.0.98 (external, cli)"
+    if (this.options?.userAgent) {
+      headers["user-agent"] = this.options.userAgent;
+    } else if (request.headers?.["user-agent"]) {
+      headers["user-agent"] = request.headers["user-agent"];
+    } else if (request.headers?.["User-Agent"]) {
+      headers["user-agent"] = request.headers["User-Agent"];
+    } else {
+      headers["user-agent"] = "claude-cli/1.0.98 (external, cli)";
+    }
+
     return {
       body: request,
       config: {

--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -22,7 +22,7 @@ export class AnthropicTransformer implements Transformer {
   private userAgent: string;
 
   constructor(private readonly options?: TransformerOptions) {
-    this.useBearer = this.options?.UseBearer ?? false;
+    this.useBearer = this.options?.useBearer ?? false;
     this.userAgent = this.options?.userAgent ?? "";
   }
 
@@ -39,8 +39,8 @@ export class AnthropicTransformer implements Transformer {
 
     // 设置 user-agent 逻辑：
     // 1. 如果 options 中有 userAgent，使用它
-    if (this.options?.userAgent) {
-      headers["user-agent"] = this.options.userAgent;
+    if (this.userAgent !== "") {
+      headers["user-agent"] = this.userAgent;
     }
     return {
       body: request,

--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -21,30 +21,21 @@ export class AnthropicTransformer implements Transformer {
   }
 
   async auth(request: any, provider: LLMProvider): Promise<any> {
-    const headers: Record<string, string | undefined> = {};
+    const headers = { ...(request.headers ?? {}) };
     
     if (this.useBearer) {
       headers["authorization"] = `Bearer ${provider.apiKey}`;
-      headers["x-api-key"] = undefined;
+      delete headers["x-api-key"];
     } else {
       headers["x-api-key"] = provider.apiKey;
-      headers["authorization"] = undefined;
+      delete headers["authorization"];
     }
 
     // 设置 user-agent 逻辑：
     // 1. 如果 options 中有 userAgent，使用它
-    // 2. 如果没有，检查原始请求中是否已有 user-agent，如果有则保持不变
-    // 3. 如果都没有，使用默认值 "claude-cli/1.0.98 (external, cli)"
     if (this.options?.userAgent) {
       headers["user-agent"] = this.options.userAgent;
-    } else if (request.headers?.["user-agent"]) {
-      headers["user-agent"] = request.headers["user-agent"];
-    } else if (request.headers?.["User-Agent"]) {
-      headers["user-agent"] = request.headers["User-Agent"];
-    } else {
-      headers["user-agent"] = "claude-cli/1.0.98 (external, cli)";
     }
-
     return {
       body: request,
       config: {

--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -19,9 +19,11 @@ export class AnthropicTransformer implements Transformer {
   endPoint = "/v1/messages";
   static TransformerName = "Anthropic";
   private useBearer: boolean;
+  private userAgent: string;
 
   constructor(private readonly options?: TransformerOptions) {
     this.useBearer = this.options?.UseBearer ?? false;
+    this.userAgent = this.options?.userAgent ?? "";
   }
 
   async auth(request: any, provider: LLMProvider): Promise<any> {

--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -13,6 +13,7 @@ import { createApiError } from "@/api/middleware";
 export class AnthropicTransformer implements Transformer {
   name = "Anthropic";
   endPoint = "/v1/messages";
+  static TransformerName = "Anthropic";
   private useBearer: boolean;
 
   constructor(private readonly options?: TransformerOptions) {


### PR DESCRIPTION
- 在 auth 方法中添加 user-agent 设置逻辑
- 支持通过 可选参数options.userAgent 自定义 user-agent
- 同时兼容 user-agent 和 User-Agent 两种格式

更好地实现了用户可选的流量伪装