### PR TITLE
解决在使用x-api-key时部分供应商认证报错的问题

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -212,13 +212,13 @@ async function sendRequestToProvider(
   }
 
   // 发送HTTP请求
-  // 准备headers，如果config.headers中没有authorization，则使用默认的Bearer token
+  // 准备headers
   const requestHeaders: Record<string, string> = {
     ...(config?.headers || {}),
   };
 
   // 只有在config.headers中没有显式设置authorization或x-api-key时，才使用默认的Bearer token
-  if (!requestHeaders.authorization && !requestHeaders['x-api-key']) {
+  if (!requestHeaders.authorization && !requestHeaders.Authorization && !requestHeaders['x-api-key']) {
     requestHeaders.Authorization = `Bearer ${provider.apiKey}`;
   }
 


### PR DESCRIPTION
解决在使用x-api-key时，请求头会传入 Authorization: 'Bearer undefined' 导致部分供应商认证报错: `鉴权header，x-api-key和Authorization不可以同时存在` 的问题；OpenAI和Anthropic格式的供应商API都已自测通过。
