### PR TITLE
feat: implement header extraction and forwarding functionality

### DIFF
--- a/src/utils/headerExtractor.ts
+++ b/src/utils/headerExtractor.ts
@@ -1,0 +1,71 @@
+/**
+ * Header 提取和过滤工具
+ * 用于从请求 headers 中提取允许转发到 LLM Provider 的 headers
+ */
+
+// 默认允许转发的 headers（白名单）
+const DEFAULT_FORWARD_HEADERS = [
+  'x-request-id',
+  'x-trace-id',
+  'x-correlation-id',
+  'user-agent',
+  'x-forwarded-for',
+  'x-real-ip',
+  'accept-language',
+];
+
+// 禁止转发的 headers（黑名单）
+const BLOCKED_HEADERS = [
+  'host',
+  'content-length',
+  'connection',
+  'transfer-encoding',
+  'authorization',  // 由 provider 自己设置
+  'x-api-key',      // 由 provider 自己设置
+];
+
+/**
+ * 从请求 headers 中提取允许转发的 headers
+ * @param headers - 原始请求 headers
+ * @param customAllowList - 自定义白名单（可选，优先级高于默认）
+ * @returns 过滤后的 headers 对象
+ */
+export function extractForwardableHeaders(
+  headers: Record<string, string | string[] | undefined>,
+  customAllowList?: string[]
+): Record<string, string> {
+  const forwarded: Record<string, string> = {};
+  const allowList = customAllowList || DEFAULT_FORWARD_HEADERS;
+
+  allowList.forEach((name) => {
+    const lowerName = name.toLowerCase();
+    
+    // 检查是否在黑名单中
+    if (BLOCKED_HEADERS.includes(lowerName)) {
+      return;
+    }
+
+    const value = headers[lowerName];
+    if (value) {
+      // 处理数组形式的 header
+      forwarded[name] = Array.isArray(value) ? value[0] : value;
+    }
+  });
+
+  return forwarded;
+}
+
+/**
+ * 从配置中获取自定义转发列表
+ * @param config - 配置对象
+ * @returns 自定义 header 列表或 undefined
+ */
+export function getForwardHeadersFromConfig(config?: any): string[] | undefined {
+  if (config?.FORWARD_HEADERS) {
+    return Array.isArray(config.FORWARD_HEADERS)
+      ? config.FORWARD_HEADERS
+      : config.FORWARD_HEADERS.split(',').map((h: string) => h.trim());
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
**功能简介**:
本次更新实现了 **header 提取与转发** 功能，主要用于从请求中提取出可转发的 HTTP headers，并允许根据配置将这些 headers 转发给下游服务。这个功能可以增强服务的灵活性，并确保仅传递必要的 headers。

**修改内容**:

1. **新增工具函数**：`extractForwardableHeaders` 和 `getForwardHeadersFromConfig` 用于提取、过滤并返回可转发的 headers。

   * `extractForwardableHeaders`：从请求中提取并过滤出允许转发的 headers。
   * `getForwardHeadersFromConfig`：根据配置获取自定义的转发头列表，优先级高于默认配置。

2. **header 白名单与黑名单**：

   * 默认允许转发的 headers 包括：`x-request-id`, `x-trace-id`, `x-correlation-id`, `user-agent` 等。
   * 禁止转发的 headers 包括：`host`, `content-length`, `connection`, `authorization` 等。

3. **路由更新**：

   * 更新了 `src/api/routes.ts` 文件，引入了新的头部提取逻辑，用于处理 HTTP 请求。

4. **功能验证**：

   * 通过添加新的测试案例，验证了提取、过滤和转发功能的正确性。

**变更目的**：

* 为了更好地支持自定义头部转发，提升系统灵活性和安全性，确保不会转发不必要或敏感的 headers。

**相关文件**:

* `src/api/routes.ts`：主要修改文件，更新了请求头提取和转发逻辑。
* `src/utils/headerExtractor.ts`：新增头部提取和过滤工具函数。

**备注**:

* 该功能默认开启，可以通过配置自定义可转发的 headers 列表，满足不同的业务需求。