### PR TITLE
feat: Add DeepseekThinkingTransformer for deepseek-reasoner model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@musistudio/llms",
-  "version": "1.0.28",
+  "version": "1.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@musistudio/llms",
-      "version": "1.0.28",
+      "version": "1.0.48",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.54.0",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -39,7 +39,8 @@ async function handleTransformerEndpoint(
     transformer,
     req.headers,
     {
-      req
+      req,
+      model: body.model
     }
   );
 
@@ -52,7 +53,8 @@ async function handleTransformerEndpoint(
     bypass,
     transformer,
     {
-      req
+      req,
+      model: body.model
     }
   );
 
@@ -65,6 +67,7 @@ async function handleTransformerEndpoint(
     bypass,
     {
       req,
+      model: body.model
     }
   );
 

--- a/src/services/provider.ts
+++ b/src/services/provider.ts
@@ -40,24 +40,37 @@ export class ProviderService {
         const transformer: LLMProvider["transformer"] = {}
 
         if (providerConfig.transformer) {
+          this.logger.info('[ProviderService] Loading transformers for provider:', providerConfig.name);
           Object.keys(providerConfig.transformer).forEach(key => {
             if (key === 'use') {
               if (Array.isArray(providerConfig.transformer.use)) {
+                this.logger.info('[ProviderService] Transformer names from config:', providerConfig.transformer.use);
                 transformer.use = providerConfig.transformer.use.map((transformer) => {
                   if (Array.isArray(transformer) && typeof transformer[0] === 'string') {
+                    this.logger.info('[ProviderService] Looking for transformer (array):', transformer[0]);
                     const Constructor = this.transformerService.getTransformer(transformer[0]);
                     if (Constructor) {
+                      this.logger.info('[ProviderService] Found transformer (array):', transformer[0]);
                       return new (Constructor as TransformerConstructor)(transformer[1]);
+                    } else {
+                      this.logger.warn('[ProviderService] Transformer NOT FOUND (array):', transformer[0]);
                     }
                   }
                   if (typeof transformer === 'string') {
+                    this.logger.info('[ProviderService] Looking for transformer (string):', transformer);
                     const transformerInstance = this.transformerService.getTransformer(transformer);
                     if (typeof transformerInstance === 'function') {
+                      this.logger.info('[ProviderService] Found transformer constructor:', transformer);
                       return new transformerInstance();
                     }
-                    return transformerInstance;
+                    if (transformerInstance) {
+                      this.logger.info('[ProviderService] Found transformer instance:', transformer);
+                      return transformerInstance;
+                    }
+                    this.logger.warn('[ProviderService] Transformer NOT FOUND (string):', transformer);
                   }
                 }).filter((transformer) => typeof transformer !== 'undefined');
+                this.logger.info('[ProviderService] Loaded transformers count:', transformer.use?.length || 0);
               }
             } else {
               if (Array.isArray(providerConfig.transformer[key]?.use)) {

--- a/src/services/transformer.ts
+++ b/src/services/transformer.ts
@@ -121,12 +121,16 @@ export class TransformerService {
 
   private async registerDefaultTransformersInternal(): Promise<void> {
     try {
+      this.logger.info('[TransformerService] Registering default transformers...');
+      this.logger.info('[TransformerService] Total transformers to register:', Object.keys(Transformers).length);
+
       Object.values(Transformers).forEach(
         (TransformerStatic: TransformerConstructor) => {
           if (
             "TransformerName" in TransformerStatic &&
             typeof TransformerStatic.TransformerName === "string"
           ) {
+            this.logger.info('[TransformerService] Registering static transformer:', TransformerStatic.TransformerName);
             this.registerTransformer(
               TransformerStatic.TransformerName,
               TransformerStatic
@@ -140,6 +144,7 @@ export class TransformerService {
             ) {
               (transformerInstance as any).logger = this.logger;
             }
+            this.logger.info('[TransformerService] Registering instance transformer:', transformerInstance.name);
             this.registerTransformer(
               transformerInstance.name!,
               transformerInstance
@@ -147,6 +152,7 @@ export class TransformerService {
           }
         }
       );
+      this.logger.info('[TransformerService] All transformers registered. Total count:', this.transformers.size);
     } catch (error) {
       this.logger.error({ error }, "transformer regist error:");
     }

--- a/src/transformer/deepseek-thinking.transformer.ts
+++ b/src/transformer/deepseek-thinking.transformer.ts
@@ -1,0 +1,96 @@
+import { UnifiedChatRequest } from "../types/llm";
+import { Transformer, TransformerContext } from "../types/transformer";
+
+/**
+ * DeepSeek Thinking Transformer
+ * 
+ * Handles DeepSeek v3.2 API requirements for reasoning_content field in assistant messages.
+ * 
+ * DeepSeek v3.2 requires:
+ * 1. All assistant messages must have reasoning_content field (can be empty string)
+ * 2. reasoning_content must be preserved from API responses for multi-turn conversations
+ * 
+ * See: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls
+ */
+export class DeepseekThinkingTransformer implements Transformer {
+  name = "deepseek-thinking";
+  logger?: any;
+
+  async transformRequestIn(
+    request: UnifiedChatRequest,
+    provider: any,
+    context: TransformerContext
+  ): Promise<UnifiedChatRequest> {
+    this.logger?.info(`[DeepseekThinkingTransformer] Processing request for model: ${context.model}`);
+    this.logger?.info(`[DeepseekThinkingTransformer] Provider model: ${provider?.model}`);
+
+    // Only apply to deepseek-reasoner model
+    const isReasonerModel = context.model === "deepseek-reasoner" ||
+                           provider?.model === "deepseek-reasoner";
+
+    this.logger?.info(`[DeepseekThinkingTransformer] Is reasoner model: ${isReasonerModel}`);
+
+    if (!isReasonerModel) {
+      this.logger?.info('[DeepseekThinkingTransformer] Skipping - not a reasoner model');
+      return request;
+    }
+
+    // Ensure all assistant messages have reasoning_content field
+    if (request.messages && Array.isArray(request.messages)) {
+      const assistantMessagesBefore = request.messages.filter((m: any) => m.role === "assistant").length;
+      this.logger?.info(`[DeepseekThinkingTransformer] Found ${assistantMessagesBefore} assistant messages`);
+
+      request.messages = request.messages.map((msg: any) => {
+        if (msg.role === "assistant") {
+          // Add empty reasoning_content if missing
+          if (msg.reasoning_content === undefined || msg.reasoning_content === null) {
+            this.logger?.info('[DeepseekThinkingTransformer] Adding reasoning_content to assistant message');
+            return {
+              ...msg,
+              reasoning_content: ""
+            };
+          } else {
+            this.logger?.info('[DeepseekThinkingTransformer] Assistant message already has reasoning_content');
+          }
+        }
+        return msg;
+      });
+    }
+
+    this.logger?.info('[DeepseekThinkingTransformer] Request transformed successfully');
+    return request;
+  }
+
+  async transformResponseOut(
+    response: Response,
+    context: TransformerContext
+  ): Promise<Response> {
+    // Only apply to deepseek-reasoner model
+    const isReasonerModel = context.model === "deepseek-reasoner";
+    
+    if (!isReasonerModel) {
+      return response;
+    }
+
+    // Handle non-streaming response
+    if (response.headers.get("Content-Type")?.includes("application/json")) {
+      const jsonResponse = await response.json();
+      
+      // Ensure reasoning_content exists in response for history preservation
+      if (jsonResponse.choices?.[0]?.message) {
+        if (!jsonResponse.choices[0].message.reasoning_content) {
+          jsonResponse.choices[0].message.reasoning_content = "";
+        }
+      }
+      
+      return new Response(JSON.stringify(jsonResponse), {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    }
+    
+    // Streaming responses are handled by the deepseek transformer
+    return response;
+  }
+}

--- a/src/transformer/index.ts
+++ b/src/transformer/index.ts
@@ -2,6 +2,7 @@ import { AnthropicTransformer } from "./anthropic.transformer";
 import { GeminiTransformer } from "./gemini.transformer";
 import { VertexGeminiTransformer } from "./vertex-gemini.transformer";
 import { DeepseekTransformer } from "./deepseek.transformer";
+import { DeepseekThinkingTransformer } from "./deepseek-thinking.transformer";
 import { TooluseTransformer } from "./tooluse.transformer";
 import { OpenrouterTransformer } from "./openrouter.transformer";
 import { MaxTokenTransformer } from "./maxtoken.transformer";
@@ -26,6 +27,7 @@ export default {
   VertexGeminiTransformer,
   VertexClaudeTransformer,
   DeepseekTransformer,
+  DeepseekThinkingTransformer,
   TooluseTransformer,
   OpenrouterTransformer,
   OpenAITransformer,


### PR DESCRIPTION
- Add DeepseekThinkingTransformer to handle reasoning_content field requirement
- Fix 'Missing reasoning_content field' error for deepseek-reasoner with tool calls
- Add model to TransformerContext in routes.ts for proper model detection
- Add comprehensive logging in transformers for debugging
- Register transformer in transformer/index.ts

Fixes issue with DeepSeek v3.2 API requiring reasoning_content field in all assistant messages when using tool calls.

Reference: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls