### PR TITLE
feat: pass through reasoning_effort in Anthropic transformer

### DIFF
--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -195,6 +195,10 @@ export class AnthropicTransformer implements Transformer {
         enabled: request.thinking.type === "enabled",
       };
     }
+    // Pass through reasoning_effort from CCR for providers like CCProxy
+    if (request.reasoning_effort) {
+      (result as any).reasoning_effort = request.reasoning_effort;
+    }
     if (request.tool_choice) {
       if (request.tool_choice.type === "tool") {
         result.tool_choice = {


### PR DESCRIPTION
Forward reasoning_effort parameter from incoming requests to downstream providers. Enables CCR to control Codex reasoning level via CCProxy.