### PR TITLE
fix(groq): remove unsupported reasoning property from requests

### DIFF
--- a/src/transformer/groq.transformer.ts
+++ b/src/transformer/groq.transformer.ts
@@ -6,6 +6,11 @@ export class GroqTransformer implements Transformer {
   name = "groq";
 
   async transformRequestIn(request: UnifiedChatRequest): Promise<UnifiedChatRequest> {
+    // Remove reasoning property - Groq doesn't support it
+    if (request.reasoning) {
+      delete request.reasoning;
+    }
+
     request.messages.forEach(msg => {
       if (Array.isArray(msg.content)) {
         (msg.content as MessageContent[]).forEach((item) => {


### PR DESCRIPTION
  Summary

  - Remove unsupported reasoning property from requests in GroqTransformer
  - Fixes 400 error when using Groq with models like moonshotai/kimi-k2-instruct

  Problem

  When using Groq provider, requests fail with:
  {"error":{"message":"property 'reasoning' is unsupported","type":"invalid_request_error"}}

  Solution

  Add reasoning property removal in transformRequestIn(), following the same pattern used by CerebrasTransformer.