### PR TITLE
fix: filter Anthropic server-side tools in Anthropic→unified conversion (xAI 400 "missing field `parameters`")

### DIFF
--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -177,15 +177,18 @@ export class AnthropicTransformer implements Transformer {
       }
     });
 
+    const tools = request.tools?.length
+      ? this.convertAnthropicToolsToUnified(request.tools)
+      : undefined;
     const result: UnifiedChatRequest = {
       messages,
       model: request.model,
       max_tokens: request.max_tokens,
       temperature: request.temperature,
       stream: request.stream,
-      tools: request.tools?.length
-        ? this.convertAnthropicToolsToUnified(request.tools)
-        : undefined,
+      // Server-side tools may all be filtered out — an empty tools array is
+      // rejected by some providers, so omit the field entirely in that case.
+      tools: tools?.length ? tools : undefined,
       tool_choice: request.tool_choice,
     };
     if (request.thinking) {
@@ -196,7 +199,16 @@ export class AnthropicTransformer implements Transformer {
       };
     }
     if (request.tool_choice) {
-      if (request.tool_choice.type === "tool") {
+      const choosesFilteredTool =
+        request.tool_choice.type === "tool" &&
+        !result.tools?.some(
+          (tool) => tool.function.name === request.tool_choice.name
+        );
+      if (!result.tools || choosesFilteredTool) {
+        // tool_choice pointing at a filtered server-side tool (or at nothing)
+        // would make providers reject the request with "unknown function".
+        delete result.tool_choice;
+      } else if (request.tool_choice.type === "tool") {
         result.tool_choice = {
           type: "function",
           function: { name: request.tool_choice.name },
@@ -243,14 +255,28 @@ export class AnthropicTransformer implements Transformer {
   }
 
   private convertAnthropicToolsToUnified(tools: any[]): UnifiedTool[] {
-    return tools.map((tool) => ({
-      type: "function",
-      function: {
-        name: tool.name,
-        description: tool.description || "",
-        parameters: tool.input_schema,
-      },
-    }));
+    return tools
+      .filter((tool) => {
+        // Anthropic server-side tools (web_search_20250305, code_execution_*,
+        // computer_*, ...) are executed by Anthropic's own infrastructure and
+        // carry no input_schema. They cannot be represented as OpenAI-style
+        // function tools: forwarding them produces `parameters: undefined`,
+        // which strict providers (e.g. xAI) reject with
+        // 400 "tools[0]: missing field `parameters`". Their type is versioned
+        // with a date suffix (`<name>_YYYYMMDD`), unlike client tools whose
+        // type is "custom" or absent.
+        return !(typeof tool.type === "string" && /_\d{8}$/.test(tool.type));
+      })
+      .map((tool) => ({
+        type: "function",
+        function: {
+          name: tool.name,
+          description: tool.description || "",
+          // A client tool without input_schema is valid for Anthropic but not
+          // for strict OpenAI-compatible providers — default to an empty schema.
+          parameters: tool.input_schema ?? { type: "object", properties: {} },
+        },
+      }));
   }
 
   private async convertOpenAIStreamToAnthropic(


### PR DESCRIPTION
### Problem

`AnthropicTransformer.convertAnthropicToolsToUnified` maps every Anthropic tool to an OpenAI-style function, taking `parameters` from `input_schema`. Anthropic **server-side tools** (`web_search_20250305`, `code_execution_*`, `computer_*`, …) carry no `input_schema` by design, so the converted entry has `parameters: undefined` — the field vanishes on serialization, and strict OpenAI-compatible providers reject the whole request:

```
400 Failed to deserialize the JSON body into the target type:
    tools[0]: missing field `parameters`
```

This is the root cause of musistudio/claude-code-router#1419 (server tools dropped/broken).

### Real-world impact

Claude Code triggers this on **every WebSearch invocation**: the CLI issues a dedicated sub-request whose `tools` array contains only the server-side `web_search` tool. Any third-party-routed session that searches the web dies with the 400 above and retries until timeout. Reproduced against xAI `grok-4.20` via claude-code-router → LiteLLM:

```bash
curl -s http://127.0.0.1:3456/v1/messages -H "content-type: application/json" -H "x-api-key: any" \
  -d '{"model":"litellm,grok-4.20","max_tokens":50,
       "tools":[{"type":"web_search_20250305","name":"web_search","max_uses":5}],
       "messages":[{"role":"user","content":"hi"}]}'
# → 400 tools[0]: missing field `parameters`
```

### Fix

- **Filter server-side tools** in `convertAnthropicToolsToUnified`. They are executed by Anthropic's own infrastructure and cannot be represented as provider function tools. Detection: versioned type suffix (`<name>_YYYYMMDD`) — client tools never have this (type is `"custom"` or absent).
- **Default missing `input_schema`** on client tools to `{"type":"object","properties":{}}` (valid for Anthropic, required by strict providers).
- **Omit `tools` entirely** when filtering empties it (some providers reject an empty tools array).
- **Drop `tool_choice`** when it points at a filtered tool or when no tools remain, avoiding "unknown function" provider errors.

The change only touches the Anthropic→unified request path, so direct Anthropic-endpoint passthrough (the `Anthropic` transformer bypass) is unaffected.

### Testing

Functional checks run with `tsx` against the patched transformer (all pass):

1. server-tool-only request → `tools` omitted
2. mixed server + client tools → only the client tool survives, schema intact
3. schema-less client tool → repaired with empty object schema
4. `tool_choice` pointing at a filtered tool → removed
5. normal `tool_choice` (type `tool`) → preserved as `{type:"function",...}`
6. `tool_choice: auto` → string passthrough unchanged

`pnpm run build` succeeds; `pnpm run lint` introduces no new errors; `tsc --noEmit` shows no diagnostics in `anthropic.transformer.ts` (pre-existing diagnostics in other files untouched). Also verified end-to-end by building claude-code-router with this patch applied to `packages/core` and replaying the failing Claude Code WebSearch scenario — the previously-fatal `tools=[web_search]` sub-requests now complete instead of 400ing.

### Note

A possible follow-up (out of scope here) is mapping `web_search_20250305` to provider-native search where available (e.g. xAI live search) instead of dropping it, so third-party-routed sessions keep real web search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)