### PR TITLE
fix: preserve Anthropic document (PDF) blocks in OpenAI transform

### DIFF
--- a/src/transformer/anthropic.transformer.ts
+++ b/src/transformer/anthropic.transformer.ts
@@ -4,6 +4,7 @@ import {
   UnifiedChatRequest,
   UnifiedMessage,
   UnifiedTool,
+  FileContent,
 } from "@/types/llm";
 import {
   Transformer,
@@ -42,6 +43,48 @@ export class AnthropicTransformer implements Transformer {
         headers,
       },
     };
+  }
+
+  // Map an Anthropic `document` content block to an OpenAI Chat Completions
+  // "file" content part. Anthropic supports several document sources; OpenAI
+  // natively accepts base64 (`file_data`) and uploaded files (`file_id`). A
+  // remote `url` source has no official OpenAI equivalent, so it is passed
+  // through as `file_url` (best-effort for OpenAI-compatible gateways) rather
+  // than dropped. `text`/`content` sources carry the text inline and are
+  // flattened to a plain text part.
+  private formatDocumentPart(part: any): FileContent | { type: "text"; text: string } {
+    const source = part?.source ?? {};
+    const filename = part?.title || source.filename;
+    if (source.type === "base64") {
+      return {
+        type: "file",
+        file: {
+          ...(filename ? { filename } : {}),
+          file_data: formatBase64(source.data, source.media_type),
+        },
+        media_type: source.media_type,
+      };
+    }
+    if (source.type === "file" && source.file_id) {
+      return { type: "file", file: { file_id: source.file_id } };
+    }
+    if (source.type === "url" && source.url) {
+      return {
+        type: "file",
+        file: {
+          ...(filename ? { filename } : {}),
+          file_url: source.url,
+        },
+      };
+    }
+    // `text`/`content` sources embed the document text directly.
+    const text =
+      typeof source.data === "string"
+        ? source.data
+        : typeof source.text === "string"
+        ? source.text
+        : "";
+    return { type: "text", text };
   }
 
   async transformRequestOut(
@@ -105,7 +148,8 @@ export class AnthropicTransformer implements Transformer {
             const textAndMediaParts = msg.content.filter(
               (c: any) =>
                 (c.type === "text" && c.text) ||
-                (c.type === "image" && c.source)
+                (c.type === "image" && c.source) ||
+                (c.type === "document" && c.source)
             );
             if (textAndMediaParts.length) {
               messages.push({
@@ -125,6 +169,9 @@ export class AnthropicTransformer implements Transformer {
                       },
                       media_type: part.source.media_type,
                     };
+                  }
+                  if (part?.type === "document") {
+                    return this.formatDocumentPart(part);
                   }
                   return part;
                 }),

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -41,7 +41,23 @@ export interface ImageContent {
   media_type: string;
 }
 
-export type MessageContent = TextContent | ImageContent;
+// OpenAI Chat Completions "file" content part (used for PDFs and other
+// documents). `file_data` is a base64 data URI; `file_id` references a file
+// uploaded via the Files API; `file_url` is a best-effort passthrough for
+// OpenAI-compatible gateways that accept a remote URL (not part of the official
+// OpenAI schema, but preferable to silently dropping the document).
+export interface FileContent {
+  type: "file";
+  file: {
+    filename?: string;
+    file_data?: string;
+    file_id?: string;
+    file_url?: string;
+  };
+  media_type?: string;
+}
+
+export type MessageContent = TextContent | ImageContent | FileContent;
 
 // 统一的消息接口
 export interface UnifiedMessage {


### PR DESCRIPTION
## Purpose

Fixes #68. `AnthropicTransformer.transformRequestOut` filtered user content to `text` + `image` only, so Anthropic `document` blocks (e.g. PDFs) were **silently dropped** on the way to an OpenAI-compatible endpoint — the model never saw the document and no error was raised.

## Scope

- `src/types/llm.ts`: add a `FileContent` type (OpenAI Chat Completions `file` content part) and include it in the `MessageContent` union.
- `src/transformer/anthropic.transformer.ts`: include `document` in the user-content filter and map each Anthropic document source to an OpenAI `file` part:
  - `base64` → `file.file_data` (base64 data URI, reusing the existing `formatBase64` helper)
  - `file`   → `file.file_id`
  - `url`    → `file.file_url` (best-effort passthrough for OpenAI-compatible gateways; not part of the official OpenAI schema, but strictly better than silently dropping the document)
  - `text` / `content` → flattened to a plain text part

Scoped intentionally to the reported Anthropic→OpenAI path; other providers' transforms are untouched.

## Testing method

The repo has no unit-test harness wired, so I verified behavior directly:

- `npm run build` — passes.
- `npm run lint` — 0 errors (only pre-existing `no-explicit-any` warnings; the touched code matches the file's existing `any` style).
- `npx tsc --noEmit` — introduces **no new** errors in the changed files (the pre-existing errors in `routes.ts` / `server.ts` / `services/*` and the two unrelated spots in `anthropic.transformer.ts` are present on `main` before this change).
- Ran `transformRequestOut` on a user message containing base64 / url / file_id document blocks plus text:
  - **before:** output parts = `text` only (documents dropped)
  - **after:** output parts = `text | file(filename+file_data) | file(file_url) | file(file_id)` — all preserved.

## Note

`url`-source documents have no official OpenAI equivalent; I map them to `file.file_url` as a best-effort passthrough rather than dropping them. Happy to gate/remove that branch if you'd prefer to only emit spec-exact `file_data`/`file_id`.